### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "django-5.1" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
Potential fix for [https://github.com/ckarrie/ckw-csgo/security/code-scanning/2](https://github.com/ckarrie/ckw-csgo/security/code-scanning/2)

In general, to fix this issue you add a `permissions` block either at the top level of the workflow (applies to all jobs) or inside each job (applies only to that job), granting only the scopes actually needed. For this workflow, the job only checks out code and runs tests; it doesn’t need to write to the repo or interact with issues/PRs. The least-privilege configuration is to grant read-only access to repository contents.

The single best fix here is to add a minimal `permissions` block at the root level of `.github/workflows/django.yml`, directly under the `on:` section (or just after it), setting `contents: read`. This will ensure that all jobs in this workflow use a `GITHUB_TOKEN` limited to read-only repository contents while preserving current behavior. No imports or other code changes are required; we only modify the YAML workflow file.

Concretely, in `.github/workflows/django.yml`, add:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–7) and the `jobs:` block (line 9). No other changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
